### PR TITLE
chore: add common gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Node modules
+node_modules/
+
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Compiled artifacts
+*.so
+*.dylib
+*.dll
+*.exe
+*.class
+build/
+dist/
+
+# Environment variables
+.env
+.env.*
+!.env.local.md
+
+# Logs
+*.log
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Editor directories
+.vscode/
+.idea/
+


### PR DESCRIPTION
## Summary
- ignore Python caches, `node_modules`, compiled artifacts and env files

## Testing
- `pytest -q` *(fails: command not found)*
- `playwright test --config=playwright.config.py --project=chromium --reporter=line` *(fails: command not found)*
- `black --check .`
- `ruff check .`