### PR TITLE
feat(api): add FastAPI endpoints with redis cache

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from .price import router as price_router
+from .ticks import router as ticks_router
+from .snapshot import router as snapshot_router
+
+router = APIRouter()
+router.include_router(price_router)
+router.include_router(ticks_router)
+router.include_router(snapshot_router)

--- a/api/deps.py
+++ b/api/deps.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from redis.asyncio import Redis
+
+
+@asynccontextmanager
+async def get_redis() -> Redis:
+    url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    client = Redis.from_url(url, decode_responses=True)
+    try:
+        yield client
+    finally:
+        await client.close()

--- a/api/price.py
+++ b/api/price.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from redis.asyncio import Redis
+
+from .deps import get_redis
+from .schemas import PriceResponse
+
+router = APIRouter()
+
+
+@router.get("/price", response_model=PriceResponse)
+async def get_price(symbol: str, redis: Redis = Depends(get_redis)) -> PriceResponse:
+    key = f"price:{symbol}"
+    data = await redis.hgetall(key)
+    if not data:
+        raise HTTPException(status_code=404, detail="Price not found")
+    return PriceResponse(
+        symbol=symbol, price=float(data["price"]), timestamp=data["timestamp"]
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import List
+
+
+class PriceResponse(BaseModel):
+    symbol: str
+    price: float
+    timestamp: datetime
+
+
+class Tick(BaseModel):
+    symbol: str
+    bid: float
+    ask: float
+    timestamp: datetime
+
+
+class SnapshotRequest(BaseModel):
+    symbols: List[str] = Field(..., min_length=1)

--- a/api/snapshot.py
+++ b/api/snapshot.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from redis.asyncio import Redis
+
+from .deps import get_redis
+from .schemas import SnapshotRequest
+
+router = APIRouter()
+
+
+async def _trigger_snapshot(symbols: list[str], redis: Redis) -> None:
+    for symbol in symbols:
+        key = f"ticks:{symbol}"
+        data = await redis.lrange(key, 0, -1)
+        # Placeholder for persistence to storage layer
+        print(f"Snapshot {symbol}: {len(data)} ticks")
+
+
+@router.post("/snapshot", status_code=202)
+async def snapshot(
+    payload: SnapshotRequest,
+    background: BackgroundTasks,
+    redis: Redis = Depends(get_redis),
+) -> None:
+    if not payload.symbols:
+        raise HTTPException(status_code=400, detail="symbols required")
+    background.add_task(_trigger_snapshot, payload.symbols, redis)

--- a/api/ticks.py
+++ b/api/ticks.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from redis.asyncio import Redis
+
+from .deps import get_redis
+from .schemas import Tick
+
+
+def _parse_tick(raw: str) -> Tick:
+    if hasattr(Tick, "model_validate_json"):
+        return Tick.model_validate_json(raw)
+    return Tick.parse_raw(raw)
+
+
+router = APIRouter()
+
+
+@router.get("/ticks", response_model=List[Tick])
+async def get_ticks(symbol: str, redis: Redis = Depends(get_redis)) -> List[Tick]:
+    key = f"ticks:{symbol}"
+    data = await redis.lrange(key, 0, -1)
+    if not data:
+        raise HTTPException(status_code=404, detail="No ticks found")
+    ticks = [_parse_tick(item) for item in data]
+    return ticks

--- a/ingest/saxo_ws.py
+++ b/ingest/saxo_ws.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Iterable
+
+from redis.asyncio import Redis
+from websockets import connect
+
+
+async def stream_prices(symbols: Iterable[str], redis: Redis) -> None:
+    uri = "wss://example.saxo.com/prices"  # placeholder
+    async with connect(uri) as ws:
+        await ws.send(json.dumps({"type": "subscribe", "symbols": list(symbols)}))
+        async for message in ws:
+            data = json.loads(message)
+            symbol = data["symbol"]
+            await redis.hset(
+                f"price:{symbol}",
+                mapping={"price": data["price"], "timestamp": data["timestamp"]},
+            )
+            await redis.expire(f"price:{symbol}", 30)
+            await redis.lpush(f"ticks:{symbol}", json.dumps(data))
+            await redis.ltrim(f"ticks:{symbol}", 0, 1000)
+            await redis.expire(f"ticks:{symbol}", 30)
+            await asyncio.sleep(0)  # yield control

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+from fastapi import FastAPI
+
+from api import router as api_router
+
+app = FastAPI(title="JH Market Data API")
+app.include_router(api_router, prefix="/api")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import router as api_router
+from api.deps import get_redis
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    async def hgetall(self, key):
+        return self.data.get(key, {})
+
+    async def lrange(self, key, start, end):
+        return self.data.get(key, [])
+
+    async def hset(self, key, mapping):
+        self.data[key] = mapping
+
+    async def lpush(self, key, value):
+        self.data.setdefault(key, []).insert(0, value)
+
+
+@asynccontextmanager
+async def override_redis():
+    yield FakeRedis()
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api")
+    return app
+
+
+@pytest.fixture
+async def client():
+    app = create_app()
+    app.dependency_overrides[get_redis] = override_redis
+    async with TestClient(app) as client:
+        yield client
+
+
+def test_price_not_found(client):
+    resp = client.get("/api/price", params={"symbol": "EUR-USD"})
+    assert resp.status_code == 404
+
+
+def test_ticks_not_found(client):
+    resp = client.get("/api/ticks", params={"symbol": "EUR-USD"})
+    assert resp.status_code == 404
+
+
+def test_snapshot(client):
+    resp = client.post("/api/snapshot", json={"symbols": ["EUR-USD"]})
+    assert resp.status_code == 202


### PR DESCRIPTION
## Summary
- implement price, ticks, and snapshot API routers
- create dependency-injected redis client
- add ingest layer example for Saxo websocket
- add FastAPI app entrypoint
- add basic tests for API routes

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q` *(fails: command not found)*
- `playwright test --config=playwright.config.py --project=chromium --reporter=line` *(fails: command not found)*