### PR TITLE
chore: add setup script and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,37 @@ A market-data service for live prices, historical ticks, and snapshots, built wi
 
 ## Table of Contents
 
-- [Features](#features)  
-- [Prerequisites](#prerequisites)  
-- [Getting Started](#getting-started)  
-- [Environment Variables](#environment-variables)  
-- [Running Locally](#running-locally)  
-- [API Usage](#api-usage)  
-- [License](#license)  
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+- [Environment Variables](#environment-variables)
+- [Running Locally](#running-locally)
+- [API Usage](#api-usage)
+- [License](#license)
 
 ## Features
 
-- Live price fetch (`/api/price?symbol=…`)  
-- Historical tick streaming/polling (`/api/ticks`)  
-- Snapshot triggering (`/api/snapshot`)  
-- SSR/ISR front-end powered by Next.js  
+- Live price fetch (`/api/price?symbol=…`)
+- Historical tick streaming/polling (`/api/ticks`)
+- Snapshot triggering (`/api/snapshot`)
+- SSR/ISR front-end powered by Next.js
 
 ## Prerequisites
 
-- Node.js ≥16  
-- Python ≥3.11  
-- Redis (Upstash) account  
-- OneDrive (Microsoft Graph) app registration  
-- GitHub repo access  
+- Node.js ≥16
+- Python ≥3.11
+- Redis (Upstash) account
+- OneDrive (Microsoft Graph) app registration
+- GitHub repo access
 
 ## Getting Started
 
-1. **Clone the repo**  
+1. **Clone the repo**
    ```bash
    git clone git@github.com:jhastrovio/JH_MDS.git
    cd JH_MDS
+   ```
+2. **Install dependencies**
+   ```bash
+   bash setup.sh
+   ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+websockets
+redis
+pyarrow
+pydantic
+pytest
+playwright

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install system prerequisites
+apt-get update
+apt-get install -y curl
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Install Node dependencies if package.json exists
+if [ -f package.json ]; then
+  npm install
+fi


### PR DESCRIPTION
## Summary
- add backend dependencies in requirements.txt
- provide setup.sh for environment preparation
- document setup instructions in README

## Testing
- `pytest -q`
- `playwright test --config=playwright.config.py --project=chromium --reporter=line` *(fails: unknown command)*
- `black --check .`
- `ruff .` *(fails: unrecognized subcommand)*