### PR TITLE
docs: expand README with setup and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,34 @@ A market-data service for live prices, historical ticks, and snapshots, built wi
 - OneDrive (Microsoft Graph) app registration
 - GitHub repo access
 
+```
 
+## Getting Started
+
+1. Clone this repository.
+2. Install Python dependencies:
+
+   ```bash
+   pip install -r requirements.txt
    ```
+3. (Optional) Install Node.js packages for the front-end:
+
+   ```bash
+   npm install
+   ```
+
+## Running Tests
+
+Run unit tests from the repository root:
+
+```bash
+cd JH_MDS
+pytest
+```
+
+If you need to run tests from another directory, set the Python path manually:
+
+```bash
+export PYTHONPATH=/path/to/JH_MDS
+pytest
+```


### PR DESCRIPTION
## Summary
- close dangling code block in README
- add Getting Started and Running Tests sections

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `playwright test --config=playwright.config.py --project=chromium --reporter=line` *(fails: unknown command 'test')*