### PR TITLE
docs: add docstrings for ingest and storage modules

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 """
 Root package initialization.
-""" 
+"""

--- a/ingest/saxo_ws.py
+++ b/ingest/saxo_ws.py
@@ -1,3 +1,10 @@
+"""Utilities for streaming foreign exchange quotes from Saxo via WebSockets.
+
+The module exposes a small wrapper around Saxo's streaming API that forwards
+incoming ticks to Redis for short-term caching. Functions are asynchronous and
+designed to run in a serverless environment.
+"""
+
 from __future__ import annotations
 
 import json
@@ -20,6 +27,15 @@ class SaxoTick(BaseModel):
 
 
 async def _connect() -> websockets.WebSocketClientProtocol:
+    """Open a WebSocket connection to the Saxo streaming endpoint.
+
+    Returns
+    -------
+    websockets.WebSocketClientProtocol
+        A connected WebSocket client ready for sending and receiving
+        streaming messages.
+    """
+
     token = os.environ.get("SAXO_API_TOKEN")
     if not token:
         raise RuntimeError("SAXO_API_TOKEN not set")

--- a/storage/on_drive.py
+++ b/storage/on_drive.py
@@ -1,3 +1,10 @@
+"""Helpers for persisting data to Microsoft OneDrive via Graph API.
+
+The functions in this module handle authentication using OAuth client
+credentials and provide utilities to upload bytes or Arrow tables as Parquet
+files. They are designed for asynchronous, serverless use.
+"""
+
 from __future__ import annotations
 
 import os
@@ -11,6 +18,19 @@ TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
 
 
 async def _get_access_token(session: aiohttp.ClientSession) -> str:
+    """Fetch an OAuth access token for the Microsoft Graph API.
+
+    Parameters
+    ----------
+    session : aiohttp.ClientSession
+        HTTP session used to perform the token request.
+
+    Returns
+    -------
+    str
+        The access token string to include in subsequent requests.
+    """
+
     data = {
         "client_id": os.environ.get("ONE_DRIVE_CLIENT_ID"),
         "client_secret": os.environ.get("ONE_DRIVE_CLIENT_SECRET"),
@@ -24,6 +44,16 @@ async def _get_access_token(session: aiohttp.ClientSession) -> str:
 
 
 async def upload_bytes(path: str, data: bytes) -> None:
+    """Upload raw bytes to OneDrive at the given path.
+
+    Parameters
+    ----------
+    path : str
+        The target file path relative to the user's OneDrive root.
+    data : bytes
+        The binary payload to upload.
+    """
+
     async with aiohttp.ClientSession() as session:
         token = await _get_access_token(session)
         url = GRAPH_BASE_URL.format(path=path)
@@ -33,11 +63,34 @@ async def upload_bytes(path: str, data: bytes) -> None:
 
 
 def table_to_bytes(table: pa.Table) -> bytes:
+    """Serialize an Arrow table to Parquet bytes in memory.
+
+    Parameters
+    ----------
+    table : pa.Table
+        The Arrow table to serialize.
+
+    Returns
+    -------
+    bytes
+        The Parquet-encoded representation of ``table``.
+    """
+
     sink = pa.BufferOutputStream()
     pq.write_table(table, sink)
     return sink.getvalue().to_pybytes()
 
 
 async def upload_table(table: pa.Table, path: str) -> None:
+    """Upload an Arrow table to OneDrive as a Parquet file.
+
+    Parameters
+    ----------
+    table : pa.Table
+        The table to persist.
+    path : str
+        Destination path for the uploaded file relative to the OneDrive root.
+    """
+
     data = table_to_bytes(table)
     await upload_bytes(path, data)


### PR DESCRIPTION
## Summary
- describe ingest.saxo_ws module purpose
- document internal connection helper
- describe storage.on_drive module
- document OneDrive helpers

## Testing
- `PYTHONPATH=. pytest tests/ -q`
- `PYTHONPATH=. pytest tests/api/ -q` *(fails: file or directory not found)*
- `ruff check .`
- `black --check .`
