### PR TITLE
chore: configure pytest options

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 """
 Root package initialization.
-""" 
+"""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- add default pytest options for async and reporting

## Testing
- `PYTHONPATH=. pytest tests/`
- `PYTHONPATH=. pytest tests/api/` *(fails: file or directory not found)*
- `black --check .`
- `ruff check .`
