### PR TITLE
chore: configure formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ A market-data service for live prices, historical ticks, and snapshots, built wi
 
 3. Set up environment variables:
 
+## Development Setup
+
+Before committing, format and lint the code:
+
+```bash
+black .
+ruff check .
+```
+
 ## Running Tests
 
 Run unit tests from the repository root:

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 """
 Root package initialization.
-""" 
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,11 @@ requires-python = ">=3.12,<3.13"
 
 [build-system]
 requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta" 
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+target-version = ["py312"]
+
+[tool.ruff]
+target-version = "py312"
+


### PR DESCRIPTION
## Summary
- configure Black and Ruff in `pyproject.toml`
- note dev formatting commands in README

## Testing
- `PYTHONPATH=. pytest tests/`
- `PYTHONPATH=. pytest tests/api/` *(fails: directory not found)*
- `black --check .`
- `ruff check .`
