### PR TITLE
feat: add canonical openapi spec

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 """
 Root package initialization.
-""" 
+"""

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,143 @@
+openapi: 3.0.1
+info:
+  title: JH Market Data API
+  version: 1.0.0
+  description: API for fetching live market prices, historical ticks, and snapshots.
+servers:
+  - url: https://api.testing.com
+    description: Production server
+  - url: https://dev.api.testing.com
+    description: Development server
+
+security:
+  - BearerAuth: []
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    PriceResponse:
+      type: object
+      properties:
+        symbol:
+          type: string
+          example: EUR-USD
+        price:
+          type: number
+          format: float
+          example: 1.0875
+        timestamp:
+          type: string
+          format: date-time
+          example: "2025-05-22T08:15:30Z"
+    Tick:
+      type: object
+      properties:
+        symbol:
+          type: string
+          example: EUR-USD
+        bid:
+          type: number
+          example: 1.0874
+        ask:
+          type: number
+          example: 1.0876
+        timestamp:
+          type: string
+          format: date-time
+          example: "2025-05-22T08:15:30Z"
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          example: 400
+        message:
+          type: string
+          example: Invalid parameter
+
+paths:
+  /api/price:
+    get:
+      summary: Get latest price for a symbol
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+            example: EUR-USD
+      responses:
+        '200':
+          description: Successful price fetch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PriceResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/ticks:
+    get:
+      summary: Stream or poll ticks for a symbol
+      parameters:
+        - name: symbol
+          in: query
+          required: true
+          schema:
+            type: string
+            example: EUR-USD
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: "2025-05-22T08:00:00Z"
+      responses:
+        '200':
+          description: List of ticks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Tick'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/snapshot:
+    post:
+      summary: Trigger snapshot write to storage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                symbols:
+                  type: array
+                  items:
+                    type: string
+                  example: ["EUR-USD", "USD-JPY"]
+      responses:
+        '202':
+          description: Snapshot scheduled
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --import-mode=prepend
+


### PR DESCRIPTION
## Summary
- add OpenAPI YAML under `api/`
- configure pytest import mode
- format root package
- keep placeholder folder for API tests

## Testing
- `black --check .`
- `ruff check .`
- `pytest tests/`
- `pytest tests/api/`
