### PR TITLE
feat: add price endpoint and auth scaffold

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .router import router
+
+app = FastAPI(title="JH Market Data API")
+app.include_router(router)

--- a/api/router.py
+++ b/api/router.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from market_data.models import PriceResponse, Tick
+from storage.redis_client import get_redis
+
+router = APIRouter(prefix="/api")
+
+_bearer = HTTPBearer()
+
+
+def _verify_jwt(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> None:
+    secret = os.environ.get("JWT_SECRET")
+    if not secret:
+        raise HTTPException(status_code=500, detail="JWT_SECRET not configured")
+    token = credentials.credentials
+    if token != secret:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+@router.get("/price", response_model=PriceResponse)
+async def get_price(symbol: str, _: Any = Depends(_verify_jwt)) -> PriceResponse:
+    redis = get_redis()
+    key = f"fx:{symbol}"
+    raw = await redis.get(key)
+    await redis.close()
+    if not raw:
+        raise HTTPException(status_code=404, detail="Symbol not found")
+    data = json.loads(raw)
+    tick = Tick(**data)
+    price = (tick.bid + tick.ask) / 2
+    return PriceResponse(symbol=tick.symbol, price=price, timestamp=tick.timestamp)

--- a/market_data/__init__.py
+++ b/market_data/__init__.py
@@ -1,0 +1,1 @@
+"""Data models for market data responses."""

--- a/market_data/models.py
+++ b/market_data/models.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class PriceResponse(BaseModel):
+    symbol: str
+    price: float
+    timestamp: str
+
+
+class Tick(BaseModel):
+    symbol: str
+    bid: float
+    ask: float
+    timestamp: str

--- a/tests/test_api_price.py
+++ b/tests/test_api_price.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from importlib import import_module  # noqa: E402
+
+router_module = import_module("api.router")
+get_price = router_module.get_price  # type: ignore[attr-defined]
+
+
+class DummyRedis:
+    def __init__(self, store: dict[str, str]):
+        self._store = store
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_get_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = json.dumps(
+        {
+            "symbol": "EUR-USD",
+            "bid": 1.0,
+            "ask": 1.1,
+            "timestamp": "2025-05-22T08:15:30Z",
+        }
+    )
+    dummy = DummyRedis({"fx:EUR-USD": data})
+    monkeypatch.setattr(router_module, "get_redis", lambda: dummy)
+    monkeypatch.setattr(router_module, "_verify_jwt", lambda credentials=None: None)
+    os.environ.setdefault("JWT_SECRET", "secret")
+
+    price = await get_price("EUR-USD")
+
+    assert price.symbol == "EUR-USD"
+    assert abs(price.price - 1.05) < 1e-6
+    assert price.timestamp == "2025-05-22T08:15:30Z"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -16,7 +16,11 @@ def test_import_modules() -> None:
     import ingest.saxo_ws as saxo_ws
     import storage.on_drive as on_drive
     import storage.redis_client as redis_client
+    from importlib import import_module
+
+    api_router = import_module("api.router")
 
     assert callable(redis_client.get_redis)
     assert hasattr(saxo_ws, "stream_quotes")
     assert hasattr(on_drive, "upload_bytes")
+    assert hasattr(api_router, "router")


### PR DESCRIPTION
## Summary
- scaffold FastAPI router with JWT check
- define Pydantic models for responses
- add basic `/api/price` endpoint using Redis
- ensure modules import properly in tests
- cover new endpoint with async test

## Testing
- `ruff check .`
- `pytest tests/`
- `pytest tests/api/` *(fails: directory not found)*