### PR TITLE
feat: add ticks & snapshot endpoints

### DIFF
--- a/api/router.py
+++ b/api/router.py
@@ -4,11 +4,13 @@ import json
 import os
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from market_data.models import PriceResponse, Tick
 from storage.redis_client import get_redis
+from storage.on_drive import upload_table
 
 router = APIRouter(prefix="/api")
 
@@ -38,3 +40,58 @@ async def get_price(symbol: str, _: Any = Depends(_verify_jwt)) -> PriceResponse
     tick = Tick(**data)
     price = (tick.bid + tick.ask) / 2
     return PriceResponse(symbol=tick.symbol, price=price, timestamp=tick.timestamp)
+
+
+@router.get("/ticks", response_model=list[Tick])
+async def get_ticks(
+    symbol: str,
+    since: str | None = None,
+    _: Any = Depends(_verify_jwt),
+) -> list[Tick]:
+    """Return cached ticks for ``symbol`` optionally filtered by ``since``."""
+    redis = get_redis()
+    key = f"ticks:{symbol}"
+    raw_ticks = await redis.lrange(key, 0, -1)
+    await redis.close()
+    if not raw_ticks:
+        raise HTTPException(status_code=404, detail="No ticks found")
+    ticks = [Tick(**json.loads(item)) for item in raw_ticks]
+    if since:
+        try:
+            cutoff = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid since timestamp")
+        ticks = [
+            t
+            for t in ticks
+            if datetime.fromisoformat(t.timestamp.replace("Z", "+00:00")) >= cutoff
+        ]
+    return ticks
+
+
+@router.post("/snapshot", status_code=status.HTTP_202_ACCEPTED)
+async def create_snapshot(
+    payload: dict[str, list[str]],
+    _: Any = Depends(_verify_jwt),
+) -> dict[str, str]:
+    symbols = payload.get("symbols")
+    if not symbols:
+        raise HTTPException(status_code=400, detail="symbols required")
+    redis = get_redis()
+    rows = []
+    for sym in symbols:
+        raw = await redis.get(f"fx:{sym}")
+        if not raw:
+            continue
+        data = json.loads(raw)
+        rows.append(data)
+    await redis.close()
+    if not rows:
+        raise HTTPException(status_code=404, detail="No data for symbols")
+    import pyarrow as pa
+
+    table = pa.Table.from_pylist(rows)
+    now = datetime.utcnow().isoformat().replace(":", "-")
+    path = f"snapshots/{now}.parquet"
+    await upload_table(table, path)
+    return {"detail": "snapshot scheduled", "path": path}

--- a/tests/test_api_snapshot.py
+++ b/tests/test_api_snapshot.py
@@ -1,0 +1,62 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from importlib import import_module  # noqa: E402
+
+router_module = import_module("api.router")
+create_snapshot = router_module.create_snapshot  # type: ignore[attr-defined]
+
+
+class DummyRedis:
+    def __init__(self, store: dict[str, str]):
+        self._store = store
+
+    async def get(self, key: str):
+        return self._store.get(key)
+
+    async def close(self):
+        pass
+
+
+class DummyUploader:
+    def __init__(self):
+        self.called = False
+        self.table = None
+        self.path = None
+
+    async def __call__(self, table, path):
+        self.called = True
+        self.table = table
+        self.path = path
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    tick = json.dumps(
+        {
+            "symbol": "EUR-USD",
+            "bid": 1.0,
+            "ask": 1.1,
+            "timestamp": "2025-05-22T08:15:00Z",
+        }
+    )
+    dummy_redis = DummyRedis({"fx:EUR-USD": tick})
+    monkeypatch.setattr(router_module, "get_redis", lambda: dummy_redis)
+    monkeypatch.setattr(router_module, "_verify_jwt", lambda credentials=None: None)
+    uploader = DummyUploader()
+    monkeypatch.setattr(router_module, "upload_table", uploader)
+    os.environ.setdefault("JWT_SECRET", "secret")
+
+    resp = await create_snapshot({"symbols": ["EUR-USD"]})
+
+    assert uploader.called
+    assert "snapshots/" in uploader.path
+    assert resp["detail"] == "snapshot scheduled"

--- a/tests/test_api_ticks.py
+++ b/tests/test_api_ticks.py
@@ -1,0 +1,62 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from importlib import import_module  # noqa: E402
+
+router_module = import_module("api.router")
+get_ticks = router_module.get_ticks  # type: ignore[attr-defined]
+
+
+class DummyRedis:
+    def __init__(self, store: dict[str, list[str]]):
+        self._store = store
+
+    async def lrange(self, key: str, start: int, end: int):
+        return self._store.get(key, [])
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_get_ticks(monkeypatch: pytest.MonkeyPatch) -> None:
+    ticks = [
+        json.dumps(
+            {
+                "symbol": "EUR-USD",
+                "bid": 1.0,
+                "ask": 1.1,
+                "timestamp": "2025-05-22T08:15:00Z",
+            }
+        ),
+        json.dumps(
+            {
+                "symbol": "EUR-USD",
+                "bid": 1.2,
+                "ask": 1.3,
+                "timestamp": "2025-05-22T08:16:00Z",
+            }
+        ),
+    ]
+    dummy = DummyRedis({"ticks:EUR-USD": ticks})
+    monkeypatch.setattr(router_module, "get_redis", lambda: dummy)
+    monkeypatch.setattr(router_module, "_verify_jwt", lambda credentials=None: None)
+    os.environ.setdefault("JWT_SECRET", "secret")
+
+    result = await get_ticks("EUR-USD")
+
+    assert len(result) == 2
+    assert result[0].bid == 1.0
+    assert result[1].ask == 1.3
+
+    result_since = await get_ticks("EUR-USD", since="2025-05-22T08:15:30Z")
+    assert len(result_since) == 1
+    assert result_since[0].bid == 1.2

--- a/todo.md
+++ b/todo.md
@@ -5,8 +5,8 @@
 ### API Implementation
 - [x] Create FastAPI router in /api directory
 - [x] Implement /api/price endpoint for latest prices
-- [ ] Implement /api/ticks endpoint for historical data
-- [ ] Implement /api/snapshot endpoint for storage
+- [x] Implement /api/ticks endpoint for historical data
+- [x] Implement /api/snapshot endpoint for storage
 - [x] Add JWT authentication middleware
 
 ### Data Ingestion
@@ -83,7 +83,6 @@
 ✅ API contract defined in OpenAPI spec
 
 ## Next Steps
-1. Implement the /api/ticks and /api/snapshot endpoints
-2. Finish the Saxo WebSocket client with error handling
-3. Set up the Next.js frontend project
-4. Implement the core Watchlist component
+1. Finish the Saxo WebSocket client with error handling
+2. Set up the Next.js frontend project
+3. Implement the core Watchlist component


### PR DESCRIPTION
## Summary
- implement `/api/ticks` endpoint for historical data
- implement `/api/snapshot` endpoint that uploads Parquet to OneDrive
- add tests for new endpoints
- mark todo items complete

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`