### PR TITLE
feat(api): validate JWT tokens

### DIFF
--- a/api/router.py
+++ b/api/router.py
@@ -7,6 +7,7 @@ from typing import Any
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
 
 from market_data.models import PriceResponse, Tick
 from storage.redis_client import get_redis
@@ -24,7 +25,9 @@ def _verify_jwt(
     if not secret:
         raise HTTPException(status_code=500, detail="JWT_SECRET not configured")
     token = credentials.credentials
-    if token != secret:
+    try:
+        jwt.decode(token, secret, algorithms=["HS256"])
+    except JWTError:
         raise HTTPException(status_code=401, detail="Invalid token")
 
 

--- a/jose/__init__.py
+++ b/jose/__init__.py
@@ -1,0 +1,4 @@
+from . import jwt
+from .exceptions import JWTError
+
+__all__ = ["jwt", "JWTError"]

--- a/jose/exceptions.py
+++ b/jose/exceptions.py
@@ -1,0 +1,2 @@
+class JWTError(Exception):
+    """Base error for JWT validation failures."""

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+import hmac
+import hashlib
+
+from .exceptions import JWTError
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+def encode(claims: dict[str, object], key: str, algorithm: str = "HS256") -> str:
+    if algorithm != "HS256":
+        raise JWTError("Unsupported algorithm")
+    header = {"alg": algorithm, "typ": "JWT"}
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(claims, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(key.encode(), signing_input, hashlib.sha256).digest()
+    sig_b64 = _b64url_encode(signature)
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+
+def decode(
+    token: str, key: str, algorithms: list[str] | str, options: dict | None = None
+) -> dict:
+    if isinstance(algorithms, str):
+        algorithms = [algorithms]
+    try:
+        header_b64, payload_b64, sig_b64 = token.split(".")
+    except ValueError as exc:
+        raise JWTError("Malformed token") from exc
+    header = json.loads(_b64url_decode(header_b64))
+    if header.get("alg") not in algorithms:
+        raise JWTError("Invalid algorithm")
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    expected = hmac.new(key.encode(), signing_input, hashlib.sha256).digest()
+    if not hmac.compare_digest(expected, _b64url_decode(sig_b64)):
+        raise JWTError("Invalid signature")
+    payload = json.loads(_b64url_decode(payload_b64))
+    if payload.get("exp") is not None and time.time() > payload["exp"]:
+        raise JWTError("Signature has expired")
+    return payload

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from importlib import import_module  # noqa: E402
+
+router_module = import_module("api.router")
+_verify_jwt = router_module._verify_jwt  # type: ignore[attr-defined]
+HTTPAuthorizationCredentials = router_module.HTTPAuthorizationCredentials
+
+from jose import jwt  # noqa: E402
+
+
+def make_credentials(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def test_invalid_token_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ.setdefault("JWT_SECRET", "secret")
+    token = jwt.encode({"exp": time.time() + 60}, "wrong", algorithm="HS256")
+    creds = make_credentials(token)
+    with pytest.raises(router_module.HTTPException) as exc:
+        _verify_jwt(creds)
+    assert exc.value.status_code == 401
+
+
+def test_expired_token_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ.setdefault("JWT_SECRET", "secret")
+    token = jwt.encode({"exp": time.time() - 10}, "secret", algorithm="HS256")
+    creds = make_credentials(token)
+    with pytest.raises(router_module.HTTPException) as exc:
+        _verify_jwt(creds)
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
- decode JWTs in `_verify_jwt` using python-jose semantics
- add minimal jose implementation for HS256 support
- test invalid and expired token handling

## Testing
- `pytest tests/`
- `pytest tests/api/`
- `pytest tests/test_jwt_auth.py -q`
