### PR TITLE
fix: handle websocket edge cases

### DIFF
--- a/ingest/saxo_ws.py
+++ b/ingest/saxo_ws.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 import json
 import os
 from typing import Iterable
+import asyncio
 
 import websockets
 from pydantic import BaseModel
 from redis.asyncio import Redis
 
 REDIS_TTL_SECONDS = 30
+MAX_TICKS_PER_SYMBOL = 100
 WS_URL = "wss://gateway.saxoapi.com/sim/openapi/streamingws/connect"
 
 
@@ -44,21 +46,49 @@ async def _connect() -> websockets.WebSocketClientProtocol:
 
 
 async def stream_quotes(symbols: Iterable[str], redis: Redis) -> None:
-    """Subscribe to Saxo streaming and persist ticks to Redis."""
-    async with await _connect() as ws:
-        await ws.send(json.dumps({"ContextId": "mds", "Instruments": list(symbols)}))
-        async for raw in ws:
+    """Subscribe to Saxo streaming and persist ticks to Redis.
+
+    The connection is re-established with exponential backoff when interrupted.
+    Both the latest tick and a capped list of recent ticks are stored. The Redis
+    client is always closed on exit.
+    """
+
+    backoff = 1
+    try:
+        while True:
             try:
-                data = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            if "Symbol" not in data:
-                continue
-            tick = SaxoTick(
-                symbol=data["Symbol"],
-                bid=float(data.get("Bid", 0)),
-                ask=float(data.get("Ask", 0)),
-                timestamp=data.get("TimeStamp", ""),
-            )
-            key = f"fx:{tick.symbol}"
-            await redis.set(key, tick.model_dump_json(), ex=REDIS_TTL_SECONDS)
+                async with await _connect() as ws:
+                    await ws.send(
+                        json.dumps({"ContextId": "mds", "Instruments": list(symbols)})
+                    )
+                    backoff = 1
+                    async for raw in ws:
+                        try:
+                            data = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        if "Symbol" not in data:
+                            continue
+                        tick = SaxoTick(
+                            symbol=data["Symbol"],
+                            bid=float(data.get("Bid", 0)),
+                            ask=float(data.get("Ask", 0)),
+                            timestamp=data.get("TimeStamp", ""),
+                        )
+                        serialized = tick.model_dump_json()
+                        key = f"fx:{tick.symbol}"
+                        await redis.set(key, serialized, ex=REDIS_TTL_SECONDS)
+
+                        list_key = f"ticks:{tick.symbol}"
+                        await redis.lpush(list_key, serialized)
+                        await redis.ltrim(list_key, 0, MAX_TICKS_PER_SYMBOL - 1)
+                        await redis.expire(list_key, REDIS_TTL_SECONDS)
+                    # exit if stream ends normally
+                    break
+            except (websockets.WebSocketException, OSError):
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 16)
+            except asyncio.CancelledError:
+                break
+    finally:
+        await redis.close()

--- a/tests/test_ingest_saxo_ws.py
+++ b/tests/test_ingest_saxo_ws.py
@@ -1,0 +1,96 @@
+import json
+import os
+import sys
+import asyncio
+from pathlib import Path
+
+import pytest
+import websockets
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import ingest.saxo_ws as saxo_ws  # noqa: E402
+
+
+class DummyRedis:
+    def __init__(self):
+        self.data: dict[str, str] = {}
+        self.lists: dict[str, list[str]] = {}
+        self.expiry: dict[str, int] = {}
+        self.closed = False
+
+    async def set(self, key: str, value: str, ex: int | None = None):
+        self.data[key] = value
+
+    async def lpush(self, key: str, value: str):
+        self.lists.setdefault(key, []).insert(0, value)
+
+    async def ltrim(self, key: str, start: int, end: int):
+        lst = self.lists.get(key, [])
+        self.lists[key] = lst[start : end + 1]
+
+    async def expire(self, key: str, ex: int):
+        self.expiry[key] = ex
+
+    async def close(self):
+        self.closed = True
+
+
+class DummyWS:
+    def __init__(self, messages, error=None):
+        self.messages = list(messages)
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def send(self, message):
+        self.sent = message
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.messages:
+            return self.messages.pop(0)
+        if self.error:
+            raise self.error
+        raise asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_reconnect_on_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    tick1 = json.dumps({"Symbol": "EUR-USD", "Bid": 1.0, "Ask": 1.1, "TimeStamp": "t1"})
+    tick2 = json.dumps({"Symbol": "EUR-USD", "Bid": 1.2, "Ask": 1.3, "TimeStamp": "t2"})
+
+    ws1 = DummyWS([tick1], error=websockets.WebSocketException("boom"))
+    ws2 = DummyWS([tick2])
+    connections = [ws1, ws2]
+    count = 0
+
+    async def fake_connect():
+        nonlocal count
+        ws = connections[count]
+        count += 1
+        return ws
+
+    monkeypatch.setattr(saxo_ws, "_connect", fake_connect)
+    os.environ.setdefault("SAXO_API_TOKEN", "token")
+
+    redis = DummyRedis()
+
+    await saxo_ws.stream_quotes(["EUR-USD"], redis)
+
+    assert count == 2
+    assert redis.closed
+    assert json.loads(redis.data["fx:EUR-USD"]) == {
+        "symbol": "EUR-USD",
+        "bid": 1.2,
+        "ask": 1.3,
+        "timestamp": "t2",
+    }

--- a/tests/test_stream_quotes.py
+++ b/tests/test_stream_quotes.py
@@ -1,0 +1,92 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import ingest.saxo_ws as saxo_ws  # noqa: E402
+
+
+class DummyWebSocket:
+    def __init__(self, messages: list[str]):
+        self._messages = messages
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def send(self, message: str):
+        self.sent.append(message)
+
+    def __aiter__(self):
+        self._iter = iter(self._messages)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class DummyRedis:
+    def __init__(self):
+        self.set_store: dict[str, str] = {}
+        self.lists: dict[str, list[str]] = {}
+        self.expiry: dict[str, int] = {}
+
+    async def set(self, key: str, value: str, ex: int | None = None):
+        self.set_store[key] = value
+
+    async def lpush(self, key: str, value: str):
+        self.lists.setdefault(key, []).insert(0, value)
+
+    async def ltrim(self, key: str, start: int, end: int):
+        lst = self.lists.get(key, [])
+        self.lists[key] = lst[start : end + 1]
+
+    async def expire(self, key: str, ex: int):
+        self.expiry[key] = ex
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_stream_quotes_populates_tick_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = [
+        json.dumps(
+            {
+                "Symbol": "EUR-USD",
+                "Bid": i,
+                "Ask": i + 0.1,
+                "TimeStamp": f"2025-05-22T08:{i:02d}:00Z",
+            }
+        )
+        for i in range(saxo_ws.MAX_TICKS_PER_SYMBOL + 5)
+    ]
+    ws = DummyWebSocket(messages)
+
+    async def dummy_connect():
+        return ws
+
+    monkeypatch.setattr(saxo_ws, "_connect", dummy_connect)
+    redis = DummyRedis()
+
+    await saxo_ws.stream_quotes(["EUR-USD"], redis)
+
+    key = "ticks:EUR-USD"
+    assert len(redis.lists[key]) == saxo_ws.MAX_TICKS_PER_SYMBOL
+    # newest tick should be first due to LPUSH
+    assert json.loads(redis.lists[key][0])["bid"] == saxo_ws.MAX_TICKS_PER_SYMBOL + 4
+    # oldest retained tick should correspond to index 5 (trimmed first 5)
+    assert json.loads(redis.lists[key][-1])["bid"] == 5


### PR DESCRIPTION
## Summary
- restore tick list logic from main branch
- exit reconnect loop when stream finishes
- update reconnection test utilities
- reintroduce tick history unit test

## Testing
- `black --check . && ruff check .`
- `pytest -q tests/`
- `pytest -q tests/api/`
